### PR TITLE
add creative support w/out duration for wrapper tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var xml = function(options) {
             icon.element(r.type, r.uri, (r.creativeType) ? { creativeType : r.creativeType } : {});
           });
         });
-        creativeType.element('Duration', c.Duration);
+        if (c.Duration) creativeType.element('Duration', c.Duration);
         var trackingEvents = creativeType.element('TrackingEvents');
         c.trackingEvents.forEach(function(trackingEvent){
           if (track) {
@@ -72,10 +72,12 @@ var xml = function(options) {
         c.videoClicks.forEach(function(videoClick){
           videoClicks.element(videoClick.type, videoClick.url, { id : videoClick.id });
         });
-        var mediaFiles = creativeType.element('MediaFiles');
-        c.mediaFiles.forEach(function(mediaFile) {
-          mediaFiles.element('MediaFile', mediaFile.attributes).cdata(mediaFile.url);
-        });
+        if (c.mediaFiles && c.mediaFiles.length > 0) {
+          var mediaFiles = creativeType.element('MediaFiles');
+          c.mediaFiles.forEach(function(mediaFile) {
+            mediaFiles.element('MediaFile', mediaFile.attributes).cdata(mediaFile.url);
+          });
+        }
       });
 
       nonLinearCreatives.forEach(function(c){

--- a/lib/creative.js
+++ b/lib/creative.js
@@ -9,7 +9,7 @@ function Creative(type, settings) {
 
   if (settings.Duration) {
     this.Duration = settings.Duration;    
-  } else if (type === 'Linear') {
+  } else if (type === 'Linear' && !settings.Wrapper) {
     throw new Error('A Duration is required for all creatives. Consider defaulting to "00:00:00"');
   }
   this.attributes = {};

--- a/test/wrapper.test.js
+++ b/test/wrapper.test.js
@@ -1,6 +1,8 @@
 var test = require('tap').test
   , VAST = require('../index.js')
-  , vast = new VAST();
+  , vast = new VAST()
+  , ad
+  , creative;
 
 test('Validate ad settings', function(t){
   t.throws(function(){
@@ -21,12 +23,14 @@ test('Validate ad settings', function(t){
   t.end();
 });
 
-vast.attachAd({ 
+ad = vast.attachAd({
     structure : 'wrapper'
   , AdSystem : 'Common name of the ad'
   , sequence : 23
   , Error: 'http://error.err'
   , VASTAdTagURI : 'http://example.com'
 }).attachImpression({ id: Date.now(), url : 'http://impression.com' });
+
+creative = ad.attachCreative('Linear', { Wrapper : true } )
 
 module.exports = vast;


### PR DESCRIPTION
Goal of this PR : include the ability to add creatives with tracking events but not set a duration or mediafile for wrapper tags

excerpt from spec : 
**2.4.1.4 Linear Creative Format within a Wrapper**
The most important difference between a Wrapper Linear creative and an Inline one is that a Wrapper 
Linear creative is absent of any media files. The only elements allowed in a Wrapper Linear creative are 
VideoClicks and TrackingEvents. These tracking elements enable tracking data to be 
collected at the Wrapper for any events that occur in the Inline Linear creative that is served following 
the Wrapper.
